### PR TITLE
add placeholder image when uploaded item has no image

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -4,6 +4,8 @@ import agent from "../agent";
 import { connect } from "react-redux";
 import { ITEM_FAVORITED, ITEM_UNFAVORITED } from "../constants/actionTypes";
 
+const placeholderImage = 'placeholder.png';
+
 const mapDispatchToProps = (dispatch) => ({
   favorite: (slug) =>
     dispatch({
@@ -37,9 +39,9 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || placeholderImage}
         className="card-img-top item-img"
-        style={{ borderRadius: "20px" }}
+        style={{ borderRadius: "20px"}}
       />
       <div className="card-body">
         <Link to={`/item/${item.slug}`} className="text-white">


### PR DESCRIPTION
# Description

Created a variable named placeholderImage and set it to the location of the placeholder image located in the public directory.

Added a conditional for the image src to route to the item image if image is available or to the placeholderImage if the image is not available.

![fix-missing-image](https://user-images.githubusercontent.com/77818241/209235435-3d6a5d3b-cbe5-43c3-a9e2-3bb2e6d9fe4c.jpg)
